### PR TITLE
feat: add support for TUNA-OBS protocol

### DIFF
--- a/app/Alspotify.js
+++ b/app/Alspotify.js
@@ -13,7 +13,6 @@ class Alspotify {
 		this.info = observable.init('api', {});
 		this.lastUri = null;
 		this.lastUpdate = -1;
-		this.lastFetch = -1;
 		this.titleRegex = /(?:[\[\(\{\【]([^\]\)\}\】]+)[\]\)\}\】]\s*)*([^\[\(\{\【\「\]\)\}\】\」\-\/]+)(?:[\[\(\{\【]([^\]\)\}\】]+)[\]\)\}\】]\s*)*/g;
 
 		const app = express();

--- a/app/Alspotify.js
+++ b/app/Alspotify.js
@@ -13,7 +13,6 @@ class Alspotify {
 		this.info = observable.init('api', {});
 		this.lastUri = null;
 		this.lastUpdate = -1;
-		this.titleRegex = /(?:[\[\(\{\【]([^\]\)\}\】]+)[\]\)\}\】]\s*)*([^\[\(\{\【\「\]\)\}\】\」\-\/]+)(?:[\[\(\{\【]([^\]\)\}\】]+)[\]\)\}\】]\s*)*/g;
 
 		const app = express();
 		app.use(cors());
@@ -86,35 +85,10 @@ class Alspotify {
 		if(typeof body.data.duration !== 'number' || !isFinite(body.data.duration) || body.data.duration < 0)
 			return;
 
-		const matchResult = Array.from(body.data.title.matchAll(this.titleRegex));
-		if(matchResult) {
-			if(matchResult.length > 1) {
-				if (matchResult[0] && matchResult[0][1]) {
-					body.data.artists.unshift(matchResult[0][1].trim());
-					body.data.title = matchResult[0][2].trim();
-				} else {
-					if (matchResult[0] && matchResult[0][2]) {
-						body.data.artists.unshift(matchResult[0][2].trim());
-					}
-					body.data.title = matchResult[1][2].trim();
-				}
-			} else {
-				if (matchResult[0][1]) {
-					body.data.artists.unshift(matchResult[0][1].trim());
-				}
-				body.data.title = matchResult[0][2].trim();
-			}
-		}
-
-		let artist = body.data.artists[0];
-		if (body.data.artists.length > 2) {
-			artist = body.data.artists[1];
-		}
-
 		this.info.$assign({
 			playing: true,
 			title: body.data.title,
-			artist: artist, // body.data.artists.join(", "),
+			artist: body.data.artists.join(", "),
 			progress: body.data.progress,
 			duration: body.data.duration
 		});

--- a/app/Alspotify.js
+++ b/app/Alspotify.js
@@ -122,7 +122,7 @@ class Alspotify {
 
 		if(body.data.cover_url && body.data.cover_url !== this.lastUri) {
 			this.lastUri = body.data.cover_url;
-			await this.updateLyric(null);
+			await this.updateLyric(body.data.lyrics);
 		}
 	}
 

--- a/app/views/MainWindow.js
+++ b/app/views/MainWindow.js
@@ -21,7 +21,7 @@ class MainWindow extends QMainWindow {
 		this.setWindowFlag(WindowType.FramelessWindowHint, true);
 		this.setWindowFlag(WindowType.WindowStaysOnTopHint, true);
 		this.setWindowFlag(WindowType.WindowTransparentForInput, true);
-		//this.setWindowFlag(WindowType.SubWindow, true);
+		this.setWindowFlag(WindowType.SubWindow, true); // TODO: System Tray
 		this.setAttribute(WidgetAttribute.WA_NoSystemBackground, true);
 		this.setAttribute(WidgetAttribute.WA_TranslucentBackground, true);
 

--- a/app/views/MainWindow.js
+++ b/app/views/MainWindow.js
@@ -5,7 +5,8 @@ const {
 	QMainWindow,
 	QWidget,
 	WidgetAttribute,
-	WindowType
+	WindowType,
+	QIcon
 } = require('@nodegui/nodegui');
 
 const LyricsView = require('../components/LyricsView');
@@ -16,10 +17,11 @@ class MainWindow extends QMainWindow {
 	constructor() {
 		super();
 		this.setWindowTitle('Alspotify');
+		this.setWindowIcon(new QIcon('../assets/IconMusic.png'));
 		this.setWindowFlag(WindowType.FramelessWindowHint, true);
 		this.setWindowFlag(WindowType.WindowStaysOnTopHint, true);
 		this.setWindowFlag(WindowType.WindowTransparentForInput, true);
-		this.setWindowFlag(WindowType.SubWindow, true);
+		//this.setWindowFlag(WindowType.SubWindow, true);
 		this.setAttribute(WidgetAttribute.WA_NoSystemBackground, true);
 		this.setAttribute(WidgetAttribute.WA_TranslucentBackground, true);
 

--- a/extensions/alspotify.js
+++ b/extensions/alspotify.js
@@ -58,8 +58,8 @@
 			return {
 				playing: true,
 				title: Spicetify.Player.data.track.metadata.title,
-				artist: Spicetify.Player.data.track.metadata.artist_name,
-				uri,
+				artists: [Spicetify.Player.data.track.metadata.artist_name],
+				cover_url: uri,
 				duration: Spicetify.Player.getDuration(),
 				progress: Spicetify.Player.getProgress(),
 				lyrics: await getLyric()
@@ -68,7 +68,7 @@
 
 		return {
 			playing: true,
-			uri,
+			cover_url: uri,
 			duration: Spicetify.Player.getDuration(),
 			progress: Spicetify.Player.getProgress()
 		};
@@ -78,15 +78,16 @@
 		const info = await getInfo();
 		previousInfo = info;
 
-		await fetch('http://localhost:29192/', {
+		await fetch('http://localhost:1608/', {
 			method: 'POST',
 			mode: 'cors',
 			headers: {
 				'Content-Type': 'application/json'
 			},
 			body: JSON.stringify({
-				...info,
-				timestamp: Date.now()
+				data: {
+					...info
+				}
 			})
 		});
 	};


### PR DESCRIPTION
# PR 요약

별도의 프로토콜을 사용하는 대신 [tuna-obs](https://github.com/univrsal/tuna) 프로토콜을 사용함으로써
`Spotify` 외 여러 뮤직 플레이어를 지원할 수 있습니다. (지원되는 플레이어 목록은 `tuna-obs` 레포지토리 참고)

# 변경점

- tuna-obs 프로토콜로 변경
- fix #8
- ~~제목이 표준화 되어있지 않은 유튜브 특성상, (최대한 많은 곡을 지원할 수 있게끔) 제목 파서가 추가됨. (단, 모든 제목이 지원되지는 않음)~~ **가사 선택기로 대체 예정**

# Example

- [YouTube Music](https://github.com/th-ch/youtube-music)

(일반적인 제목 형태)
![image](https://user-images.githubusercontent.com/16558115/212670578-e0b4ba42-27a7-42a6-b695-35ca5bf4329c.png)

(제목 형태가 다른 경우)
![image](https://user-images.githubusercontent.com/16558115/212671867-9891d85f-bf30-4f83-9d77-42d9a707edbf.png)

